### PR TITLE
Dev/inf 1618

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ plugins {
 	id 'eclipse'
 	id 'com.github.kt3k.coveralls' version '2.6.3'
 	id 'jacoco'
+	id 'org.sonarqube' version '2.0.1'
 }
 
 compileJava.options.encoding = 'UTF-8'
@@ -87,7 +88,9 @@ uploadArchives {
 	println "Uploading ${rootProject.name} version ${version} to maven central."
 }
 
-jacoco { toolVersion = '0.7.6.201602180812' }
+ext.jacocoVersion = System.properties['jacoco.version'] ?: '0.7.6.201602180812'
+
+jacoco { toolVersion = jacocoVersion }
 
 jacocoTestReport {
 	reports { xml.enabled = true }
@@ -118,4 +121,11 @@ artifacts {
 signing {
 	required { gradle.taskGraph.hasTask("uploadArchives") }
 	sign configurations.archives
+}
+
+sonarqube {
+	properties {
+		property "sonar.projectName", "TEST-Hub-Gradle-Plugin"
+		property "sonar.projectKey", "com.blackducksoftware:test-hub-gradle-plugin"
+	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -122,10 +122,3 @@ signing {
 	required { gradle.taskGraph.hasTask("uploadArchives") }
 	sign configurations.archives
 }
-
-sonarqube {
-	properties {
-		property "sonar.projectName", "TEST-Hub-Gradle-Plugin"
-		property "sonar.projectKey", "com.blackducksoftware:test-hub-gradle-plugin"
-	}
-}

--- a/build.gradle
+++ b/build.gradle
@@ -89,7 +89,6 @@ uploadArchives {
 }
 
 ext.jacocoVersion = System.properties['jacoco.version'] ?: '0.7.6.201602180812'
-
 jacoco { toolVersion = jacocoVersion }
 
 jacocoTestReport {


### PR DESCRIPTION
Add configuration for sonarqube.

Required change to make jacoco version configurable, as not all sonarqube versions handle Jacoco versions that are used by Gradle by default.

Specific configuration for Sonarqube can be passed on the command line of the build:

./gradlew clean sonarqube -Djacoco.version=<jacocoVersion> -Dsonar.host.url=<sonarqube.server>:<sonarqube.port> -Dsonar.jdbc.url=<sonarqube.jdbc.url.string> -Dsonar.jdbc.driver=<sonarqube.driver> -Dsonar.jdbc.username=<username> -Dsonar.jdbc.password=<password> -Dhttp.nonProxyHosts=<non-proxy-hosts>