### PR TITLE
Handle case where the root project's child projects have subprojects

### DIFF
--- a/src/main/java/com/blackducksoftware/integration/gradle/DependencyGatherer.java
+++ b/src/main/java/com/blackducksoftware/integration/gradle/DependencyGatherer.java
@@ -66,7 +66,14 @@ public class DependencyGatherer {
 
 		getProjectDependencies(rootProject, children);
 		for (final Project childProject : rootProject.getChildProjects().values()) {
-			getProjectDependencies(childProject, children);
+			// do the child projects have subprojects?
+			if (childProject.getSubprojects() != null && childProject.getSubprojects().size() > 0) {
+				for (final Project grandChild: childProject.getSubprojects()) {
+					getProjectDependencies(grandChild, children);
+				}
+			} else {
+				getProjectDependencies(childProject, children);
+			}
 		}
 
 		final File file = pluginHelper.getBdioFile(output, artifactId);

--- a/src/main/java/com/blackducksoftware/integration/gradle/DependencyGatherer.java
+++ b/src/main/java/com/blackducksoftware/integration/gradle/DependencyGatherer.java
@@ -65,15 +65,8 @@ public class DependencyGatherer {
 		final DependencyNode root = new DependencyNode(projectGav, children);
 
 		getProjectDependencies(rootProject, children);
-		for (final Project childProject : rootProject.getChildProjects().values()) {
-			// do the child projects have subprojects?
-			if (childProject.getSubprojects() != null && childProject.getSubprojects().size() > 0) {
-				for (final Project grandChild: childProject.getSubprojects()) {
-					getProjectDependencies(grandChild, children);
-				}
-			} else {
-				getProjectDependencies(childProject, children);
-			}
+		for (final Project childProject : rootProject.getAllprojects()) {
+			getProjectDependencies(childProject, children);
 		}
 
 		final File file = pluginHelper.getBdioFile(output, artifactId);


### PR DESCRIPTION
Previously the plugin would only evaluate the `rootProject`'s children
projects.  This works fine if the root's children are the actual projects
in the case where the root's children are only a root for rootProjects's
children's children, rootProject's grand children, this is not enough.

Now for each child project of root we check for subproject of the children.

If grand children project's are found then add their dependencies to the
report