### PR TITLE
Use gradle's default reports output location for blackduck reports

### DIFF
--- a/src/main/java/com/blackducksoftware/integration/gradle/PluginHelper.java
+++ b/src/main/java/com/blackducksoftware/integration/gradle/PluginHelper.java
@@ -43,9 +43,9 @@ public class PluginHelper {
 			file = new File(baseDirectory);
 		} else if (project.getRootProject() != null) {
 			final Project rootProject = project.getRootProject();
-			file = rootProject.getProjectDir();
+			file = new File(rootProject.getBuildDir(), "reports");
 		} else {
-			file = project.getProjectDir();
+			file = new File(project.getBuildDir(), "reports");
 		}
 
 		blackDuckDirectory = new File(file, "BlackDuck");


### PR DESCRIPTION
Currently the default output is `$projectDir/BlackDuck`, this is
a non standard report output location.  The gradle standard output
location would be `$project.buildDir/reports/*`.  This patch will
let the plugin use the gradle default output location.  This will
also mean that the clean task will now correctly remove previous
reports, as expected.  Previously the clean task would ignore the
created reports in `$projectDir/BlackDuck` or require custom code
to allow clean up of BlackDuck reports.