### PR TITLE
Only print uploading message during builds with the `uploadArchives` task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,8 +83,13 @@ uploadArchives {
 			}
 		}
 	}
+}
 
-	println "Uploading ${rootProject.name} version ${version} to maven central."
+gradle.taskGraph.whenReady {
+	// only print uploading message if actually uploading to remotes
+	if (gradle.taskGraph.hasTask(":uploadArchives")) {
+		println "Uploading ${rootProject.name} version ${version} to maven central."
+	}
 }
 
 jacoco { toolVersion = '0.7.6.201602180812' }


### PR DESCRIPTION
No impact to build artifacts or tests, just avoiding printing a possibly inaccurate message during every build.