### PR TITLE
Set the output directory for the bdio file to be in the rootProject's…

### DIFF
--- a/src/main/java/com/blackducksoftware/integration/gradle/BdioHelper.java
+++ b/src/main/java/com/blackducksoftware/integration/gradle/BdioHelper.java
@@ -13,6 +13,14 @@ public class BdioHelper {
 	public BdioHelper(final Project project) {
 		this.project = project;
 	}
+	
+	public void setBlackDuckReports(File blackDuckReports){
+		this.blackDuckReports = blackDuckReports;
+	}
+	
+	public File getBlackDuckReports(){
+		return this.blackDuckReports;
+	}
 
 	public boolean ensureReportsDirectoryExists() {
 		File reportsDirectory;

--- a/src/main/java/com/blackducksoftware/integration/gradle/DependencyGatherer.java
+++ b/src/main/java/com/blackducksoftware/integration/gradle/DependencyGatherer.java
@@ -94,6 +94,7 @@ public class DependencyGatherer {
 			getProjectDependencies(childProject, children);
 		}
 		logger.info("creating bdio file");
+		bdioHelper.setBlackDuckReports(new File(rootProject.getBuildDir(), "blackduck"));
 		final File file = bdioHelper.getBdioFile(rootProject);
 		try (final OutputStream outputStream = new FileOutputStream(file)) {
 			final BdioConverter bdioConverter = new BdioConverter();


### PR DESCRIPTION
… build directory.

The blackDuckReports directory wasn't being set.  I configured it to default to the $rootProject.buildDir/blackduck folder.