### PR TITLE
adding outputDirectory back to config

### DIFF
--- a/src/main/java/com/blackducksoftware/integration/gradle/DependencyGatherer.java
+++ b/src/main/java/com/blackducksoftware/integration/gradle/DependencyGatherer.java
@@ -49,15 +49,15 @@ public class DependencyGatherer {
 	public final static String PROPERTY_HUB_PROJECT_VERSION = "hubProjectVersion";
 	private final Logger logger = LoggerFactory.getLogger(DependencyGatherer.class);
 
-	private final BdioHelper bdioHelper;
+	private final TaskHelper taskHelper;
 	private final Project rootProject;
 	final Map<String, DependencyNode> visitedMap = new HashMap<>();
 	private final String hubProjectName;
 	private final String hubProjectVersion;
 
-	public DependencyGatherer(final BdioHelper bdioHelper, final Project project, final String hubProjectName,
+	public DependencyGatherer(final TaskHelper taskHelper, final Project project, final String hubProjectName,
 			final String hubProjectVersion) {
-		this.bdioHelper = bdioHelper;
+		this.taskHelper = taskHelper;
 		this.rootProject = project;
 		this.hubProjectName = hubProjectName;
 		this.hubProjectVersion = hubProjectVersion;
@@ -94,7 +94,7 @@ public class DependencyGatherer {
 			getProjectDependencies(childProject, children);
 		}
 		logger.info("creating bdio file");
-		final File file = bdioHelper.getBdioFile(rootProject);
+		final File file = taskHelper.getBdioFile(rootProject);
 		try (final OutputStream outputStream = new FileOutputStream(file)) {
 			final BdioConverter bdioConverter = new BdioConverter();
 			final CommonBomFormatter commonBomFormatter = new CommonBomFormatter(bdioConverter);

--- a/src/main/java/com/blackducksoftware/integration/gradle/HubBdioDeployer.java
+++ b/src/main/java/com/blackducksoftware/integration/gradle/HubBdioDeployer.java
@@ -51,7 +51,7 @@ import com.blackducksoftware.integration.hub.rest.RestConnection;
 public class HubBdioDeployer {
 	private final Logger logger = LoggerFactory.getLogger(HubBdioDeployer.class);
 
-	private final BdioHelper bdioHelper;
+	private final TaskHelper taskHelper;
 	private final Project project;
 	private final String hubUrl;
 	private final String hubUsername;
@@ -63,11 +63,11 @@ public class HubBdioDeployer {
 	private final String hubProxyUsername;
 	private final String hubProxyPassword;
 
-	public HubBdioDeployer(final BdioHelper bdioHelper, final Project project, final String hubUrl,
+	public HubBdioDeployer(final TaskHelper taskHelper, final Project project, final String hubUrl,
 			final String hubUsername, final String hubPassword, final String hubTimeout, final String hubProxyHost,
 			final String hubProxyPort, final String hubNoProxyHosts, final String hubProxyUsername,
 			final String hubProxyPassword) {
-		this.bdioHelper = bdioHelper;
+		this.taskHelper = taskHelper;
 		this.project = project;
 		this.hubUrl = hubUrl;
 		this.hubUsername = hubUsername;
@@ -82,7 +82,7 @@ public class HubBdioDeployer {
 
 	public void deployToHub() {
 		logger.info("Deploying Black Duck I/O output");
-		final File file = bdioHelper.getBdioFile(project);
+		final File file = taskHelper.getBdioFile(project);
 
 		final HubServerConfigBuilder builder = new HubServerConfigBuilder();
 		builder.setHubUrl(hubUrl);

--- a/src/main/java/com/blackducksoftware/integration/gradle/HubGradlePlugin.java
+++ b/src/main/java/com/blackducksoftware/integration/gradle/HubGradlePlugin.java
@@ -26,6 +26,7 @@ import org.gradle.api.Project;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.blackducksoftware.integration.gradle.task.CreateFlatDependencyList;
 import com.blackducksoftware.integration.gradle.task.CreateHubOutput;
 import com.blackducksoftware.integration.gradle.task.DeployHubOutput;
 
@@ -38,37 +39,49 @@ public class HubGradlePlugin implements Plugin<Project> {
 			return;
 		}
 
-		final BdioHelper bdioHelper = new BdioHelper(project);
+		final TaskHelper taskHelper = new TaskHelper(project);
 
 		if (null == project.getTasks().findByName("createHubOutput")) {
-			createCreateHubOutputTask(project, bdioHelper);
+			createCreateHubOutputTask(project, taskHelper);
 		}
 
 		if (null == project.getTasks().findByName("deployHubOutput")) {
-			createDeployHubOutputTask(project, bdioHelper);
+			createDeployHubOutputTask(project, taskHelper);
 		}
 	}
 
-	private void createCreateHubOutputTask(final Project project, final BdioHelper bdioHelper) {
+	private void createCreateHubOutputTask(final Project project, final TaskHelper taskHelper) {
 		logger.info(String.format("Configuring createHubOutput task for project path: %s", project.getPath()));
 
 		final CreateHubOutput createHubOutputTask = project.getTasks().create("createHubOutput", CreateHubOutput.class);
 		createHubOutputTask.setDescription("Generate the bdio file.");
 		createHubOutputTask.setGroup("reporting");
-		createHubOutputTask.setBdioHelper(bdioHelper);
+		createHubOutputTask.taskHelper = taskHelper;
 
 		logger.info("Successfully configured createHubOutput");
 	}
 
-	private void createDeployHubOutputTask(final Project project, final BdioHelper bdioHelper) {
+	private void createDeployHubOutputTask(final Project project, final TaskHelper taskHelper) {
 		logger.info(String.format("Configuring deployHubOutput task for project path: %s", project.getPath()));
 
 		final DeployHubOutput deployHubOutputTask = project.getTasks().create("deployHubOutput", DeployHubOutput.class);
 		deployHubOutputTask.setDescription("Deploy the bdio file to the specified Hub server.");
 		deployHubOutputTask.setGroup("reporting");
-		deployHubOutputTask.setBdioHelper(bdioHelper);
+		deployHubOutputTask.taskHelper = taskHelper;
 
 		logger.info("Successfully configured deployHubOutput");
+	}
+
+	private void createFlatDependencyListTask(final Project project, final TaskHelper taskHelper) {
+		logger.info(String.format("Configuring createHubOutput task for project path: %s", project.getPath()));
+
+		final CreateFlatDependencyList createFlatDependencyListTask = project.getTasks()
+				.create("createFlatDependencyList", CreateFlatDependencyList.class);
+		createFlatDependencyListTask.setDescription("Generate a flat list of unique dependencies.");
+		createFlatDependencyListTask.setGroup("reporting");
+		createFlatDependencyListTask.taskHelper = taskHelper;
+
+		logger.info("Successfully configured createHubOutput");
 	}
 
 }

--- a/src/main/java/com/blackducksoftware/integration/gradle/TaskHelper.java
+++ b/src/main/java/com/blackducksoftware/integration/gradle/TaskHelper.java
@@ -2,28 +2,34 @@ package com.blackducksoftware.integration.gradle;
 
 import java.io.File;
 
+import org.apache.commons.lang3.StringUtils;
 import org.gradle.api.Project;
 
 import com.blackducksoftware.integration.build.bdio.Constants;
 
-public class BdioHelper {
+public class TaskHelper {
 	private final Project project;
 	private File blackDuckReports;
 
-	public BdioHelper(final Project project) {
+	public TaskHelper(final Project project) {
 		this.project = project;
 	}
 
-	public boolean ensureReportsDirectoryExists() {
-		File reportsDirectory;
-		if (project.getRootProject() != null) {
-			final Project rootProject = project.getRootProject();
-			reportsDirectory = new File(rootProject.getBuildDir(), "reports");
+	public boolean ensureReportsDirectoryExists(final String userSpecifiedDirectory) {
+		if (StringUtils.isNotBlank(userSpecifiedDirectory)) {
+			blackDuckReports = new File(userSpecifiedDirectory);
 		} else {
-			reportsDirectory = new File(project.getBuildDir(), "reports");
+			File reportsDirectory;
+			if (project.getRootProject() != null) {
+				final Project rootProject = project.getRootProject();
+				reportsDirectory = new File(rootProject.getBuildDir(), "reports");
+			} else {
+				reportsDirectory = new File(project.getBuildDir(), "reports");
+			}
+
+			blackDuckReports = new File(reportsDirectory, "blackduck");
 		}
 
-		final File blackDuckReports = new File(reportsDirectory, "blackduck");
 		return blackDuckReports.mkdirs();
 	}
 

--- a/src/main/java/com/blackducksoftware/integration/gradle/task/CreateFlatDependencyList.java
+++ b/src/main/java/com/blackducksoftware/integration/gradle/task/CreateFlatDependencyList.java
@@ -1,0 +1,10 @@
+package com.blackducksoftware.integration.gradle.task;
+
+import org.gradle.api.DefaultTask;
+
+import com.blackducksoftware.integration.gradle.TaskHelper;
+
+public class CreateFlatDependencyList extends DefaultTask {
+	public TaskHelper taskHelper;
+
+}

--- a/src/main/java/com/blackducksoftware/integration/gradle/task/CreateHubOutput.java
+++ b/src/main/java/com/blackducksoftware/integration/gradle/task/CreateHubOutput.java
@@ -27,46 +27,23 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.Project;
 import org.gradle.api.tasks.TaskAction;
 
-import com.blackducksoftware.integration.gradle.BdioHelper;
 import com.blackducksoftware.integration.gradle.DependencyGatherer;
+import com.blackducksoftware.integration.gradle.TaskHelper;
 
 public class CreateHubOutput extends DefaultTask {
-	private BdioHelper bdioHelper;
-	private String hubProjectName;
-	private String hubProjectVersion;
+	public TaskHelper taskHelper;
+	public String hubProjectName;
+	public String hubProjectVersion;
+	public String outputDirectory;
 
 	@TaskAction
 	public void gatherDependencies() throws IOException {
-		bdioHelper.ensureReportsDirectoryExists();
+		taskHelper.ensureReportsDirectoryExists(outputDirectory);
 		final Project project = getProject();
 
-		final DependencyGatherer dependencyGatherer = new DependencyGatherer(bdioHelper, project, hubProjectName,
+		final DependencyGatherer dependencyGatherer = new DependencyGatherer(taskHelper, project, hubProjectName,
 				hubProjectVersion);
 		dependencyGatherer.handleBdioOutput();
-	}
-
-	public BdioHelper getBdioHelper() {
-		return bdioHelper;
-	}
-
-	public void setBdioHelper(final BdioHelper bdioHelper) {
-		this.bdioHelper = bdioHelper;
-	}
-
-	public String getHubProjectName() {
-		return hubProjectName;
-	}
-
-	public void setHubProjectName(final String hubProjectName) {
-		this.hubProjectName = hubProjectName;
-	}
-
-	public String getHubProjectVersion() {
-		return hubProjectVersion;
-	}
-
-	public void setHubProjectVersion(final String hubProjectVersion) {
-		this.hubProjectVersion = hubProjectVersion;
 	}
 
 }

--- a/src/main/java/com/blackducksoftware/integration/gradle/task/DeployHubOutput.java
+++ b/src/main/java/com/blackducksoftware/integration/gradle/task/DeployHubOutput.java
@@ -27,110 +27,31 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.Project;
 import org.gradle.api.tasks.TaskAction;
 
-import com.blackducksoftware.integration.gradle.BdioHelper;
 import com.blackducksoftware.integration.gradle.HubBdioDeployer;
+import com.blackducksoftware.integration.gradle.TaskHelper;
 
 public class DeployHubOutput extends DefaultTask {
-	private BdioHelper bdioHelper;
-	private String hubUrl;
-	private String hubUsername;
-	private String hubPassword;
-	private String hubTimeout;
-	private String hubProxyHost;
-	private String hubProxyPort;
-	private String hubNoProxyHosts;
-	private String hubProxyUsername;
-	private String hubProxyPassword;
+	public TaskHelper taskHelper;
+	public String hubUrl;
+	public String hubUsername;
+	public String hubPassword;
+	public String hubTimeout;
+	public String hubProxyHost;
+	public String hubProxyPort;
+	public String hubNoProxyHosts;
+	public String hubProxyUsername;
+	public String hubProxyPassword;
+	public String outputDirectory;
 
 	@TaskAction
 	public void deployBdioFileToHub() throws IOException {
-		bdioHelper.ensureReportsDirectoryExists();
+		taskHelper.ensureReportsDirectoryExists(outputDirectory);
 		final Project project = getProject();
 
-		final HubBdioDeployer hubBdioDeployer = new HubBdioDeployer(bdioHelper, project, hubUrl, hubUsername,
+		final HubBdioDeployer hubBdioDeployer = new HubBdioDeployer(taskHelper, project, hubUrl, hubUsername,
 				hubPassword, hubTimeout, hubProxyHost, hubProxyPort, hubNoProxyHosts, hubProxyUsername,
 				hubProxyPassword);
 		hubBdioDeployer.deployToHub();
-	}
-
-	public BdioHelper getBdioHelper() {
-		return bdioHelper;
-	}
-
-	public void setBdioHelper(final BdioHelper bdioHelper) {
-		this.bdioHelper = bdioHelper;
-	}
-
-	public String getHubUrl() {
-		return hubUrl;
-	}
-
-	public void setHubUrl(final String hubUrl) {
-		this.hubUrl = hubUrl;
-	}
-
-	public String getHubUsername() {
-		return hubUsername;
-	}
-
-	public void setHubUsername(final String hubUsername) {
-		this.hubUsername = hubUsername;
-	}
-
-	public String getHubPassword() {
-		return hubPassword;
-	}
-
-	public void setHubPassword(final String hubPassword) {
-		this.hubPassword = hubPassword;
-	}
-
-	public String getHubTimeout() {
-		return hubTimeout;
-	}
-
-	public void setHubTimeout(final String hubTimeout) {
-		this.hubTimeout = hubTimeout;
-	}
-
-	public String getHubProxyHost() {
-		return hubProxyHost;
-	}
-
-	public void setHubProxyHost(final String hubProxyHost) {
-		this.hubProxyHost = hubProxyHost;
-	}
-
-	public String getHubProxyPort() {
-		return hubProxyPort;
-	}
-
-	public void setHubProxyPort(final String hubProxyPort) {
-		this.hubProxyPort = hubProxyPort;
-	}
-
-	public String getHubNoProxyHosts() {
-		return hubNoProxyHosts;
-	}
-
-	public void setHubNoProxyHosts(final String hubNoProxyHosts) {
-		this.hubNoProxyHosts = hubNoProxyHosts;
-	}
-
-	public String getHubProxyUsername() {
-		return hubProxyUsername;
-	}
-
-	public void setHubProxyUsername(final String hubProxyUsername) {
-		this.hubProxyUsername = hubProxyUsername;
-	}
-
-	public String getHubProxyPassword() {
-		return hubProxyPassword;
-	}
-
-	public void setHubProxyPassword(final String hubProxyPassword) {
-		this.hubProxyPassword = hubProxyPassword;
 	}
 
 }


### PR DESCRIPTION
If you omit the outputDirectory, the report should be created in project.buildDir/reports/blackduck/ but if outputDirectory is specified, the report will be created there and if the outputDirectory does not exist, we will attempt to create it.